### PR TITLE
Revert "show prefer_dedicated_media_query_method lint for indirect pr…

### DIFF
--- a/example/lib/lints/flutter/prefer_dedicated_media_query_method_example.dart
+++ b/example/lib/lints/flutter/prefer_dedicated_media_query_method_example.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: unused_local_variable, deprecated_member_use, max_lines_for_function
+// ignore_for_file: unused_local_variable, deprecated_member_use
 
 import 'package:flutter/widgets.dart';
 
@@ -7,49 +7,6 @@ class Example extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final mq = MediaQuery.of(context);
-
-    // expect_lint: prefer_dedicated_media_query_method
-    final mqaccessibleNavigation = mq.accessibleNavigation;
-    // expect_lint: prefer_dedicated_media_query_method
-    final mqalwaysUse24HourFormat = mq.alwaysUse24HourFormat;
-    // expect_lint: prefer_dedicated_media_query_method
-    final mqboldText = mq.boldText;
-    // expect_lint: prefer_dedicated_media_query_method
-    final mqdevicePixelRatio = mq.devicePixelRatio;
-    // expect_lint: prefer_dedicated_media_query_method
-    final mqdisableAnimations = mq.disableAnimations;
-    // expect_lint: prefer_dedicated_media_query_method
-    final mqdisplayFeatures = mq.displayFeatures;
-    // expect_lint: prefer_dedicated_media_query_method
-    final mqgestureSettings = mq.gestureSettings;
-    // expect_lint: prefer_dedicated_media_query_method
-    final mqhighContrast = mq.highContrast;
-    // expect_lint: prefer_dedicated_media_query_method
-    final mqinvertColors = mq.invertColors;
-    // expect_lint: prefer_dedicated_media_query_method
-    final mqnavigationMode = mq.navigationMode;
-    // expect_lint: prefer_dedicated_media_query_method
-    final mqonOffSwitchLabels = mq.onOffSwitchLabels;
-    // expect_lint: prefer_dedicated_media_query_method
-    final mqorientation = mq.orientation;
-    // expect_lint: prefer_dedicated_media_query_method
-    final mqpadding = mq.padding;
-    // expect_lint: prefer_dedicated_media_query_method
-    final mqplatformBrightness = mq.platformBrightness;
-    // expect_lint: prefer_dedicated_media_query_method
-    final mqsize = mq.size;
-    // expect_lint: prefer_dedicated_media_query_method
-    final mqsystemGestureInsets = mq.systemGestureInsets;
-    // expect_lint: prefer_dedicated_media_query_method
-    final mqtextScaleFactor = mq.textScaleFactor;
-    // expect_lint: prefer_dedicated_media_query_method
-    final mqtextScaler = mq.textScaler;
-    // expect_lint: prefer_dedicated_media_query_method
-    final mqviewInsets = mq.viewInsets;
-    // expect_lint: prefer_dedicated_media_query_method
-    final mqviewPadding = mq.viewPadding.bottom;
-
     // expect_lint: prefer_dedicated_media_query_method
     final accessibleNavigation = MediaQuery.of(context).accessibleNavigation;
     // expect_lint: prefer_dedicated_media_query_method


### PR DESCRIPTION
The previous PR adds support to indirect `MediaQuery.of(context)` call to the `prefer_dedicated_media_query_method` lint.

```dart
final mq = MediaQuery.of(context);
final size = mq.size;
```

However, the implementation could not handle below case

```dart
void fn(MediaQueryData mq){
  final size = mq.size; // lint should not warn here
}
```

And the quick fix fails if the name of the `BuildContext` is not `context`.

```dart
final mq = MediaQuery.of(c);
final size = mq.size; // final size = MediaQuery.sizeOf(context) instead of final size = MediaQuery.sizeOf(c)
```