### PR TITLE
(Revised) show prefer_dedicated_media_query_method lint for indirect propery access too

### DIFF
--- a/example/lib/lints/flutter/prefer_dedicated_media_query_method_example.dart
+++ b/example/lib/lints/flutter/prefer_dedicated_media_query_method_example.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: unused_local_variable, deprecated_member_use
+// ignore_for_file: unused_local_variable, deprecated_member_use, max_lines_for_function
 
 import 'package:flutter/widgets.dart';
 
@@ -7,6 +7,49 @@ class Example extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final mq = MediaQuery.of(context);
+
+    // expect_lint: prefer_dedicated_media_query_method
+    final mqaccessibleNavigation = mq.accessibleNavigation;
+    // expect_lint: prefer_dedicated_media_query_method
+    final mqalwaysUse24HourFormat = mq.alwaysUse24HourFormat;
+    // expect_lint: prefer_dedicated_media_query_method
+    final mqboldText = mq.boldText;
+    // expect_lint: prefer_dedicated_media_query_method
+    final mqdevicePixelRatio = mq.devicePixelRatio;
+    // expect_lint: prefer_dedicated_media_query_method
+    final mqdisableAnimations = mq.disableAnimations;
+    // expect_lint: prefer_dedicated_media_query_method
+    final mqdisplayFeatures = mq.displayFeatures;
+    // expect_lint: prefer_dedicated_media_query_method
+    final mqgestureSettings = mq.gestureSettings;
+    // expect_lint: prefer_dedicated_media_query_method
+    final mqhighContrast = mq.highContrast;
+    // expect_lint: prefer_dedicated_media_query_method
+    final mqinvertColors = mq.invertColors;
+    // expect_lint: prefer_dedicated_media_query_method
+    final mqnavigationMode = mq.navigationMode;
+    // expect_lint: prefer_dedicated_media_query_method
+    final mqonOffSwitchLabels = mq.onOffSwitchLabels;
+    // expect_lint: prefer_dedicated_media_query_method
+    final mqorientation = mq.orientation;
+    // expect_lint: prefer_dedicated_media_query_method
+    final mqpadding = mq.padding;
+    // expect_lint: prefer_dedicated_media_query_method
+    final mqplatformBrightness = mq.platformBrightness;
+    // expect_lint: prefer_dedicated_media_query_method
+    final mqsize = mq.size;
+    // expect_lint: prefer_dedicated_media_query_method
+    final mqsystemGestureInsets = mq.systemGestureInsets;
+    // expect_lint: prefer_dedicated_media_query_method
+    final mqtextScaleFactor = mq.textScaleFactor;
+    // expect_lint: prefer_dedicated_media_query_method
+    final mqtextScaler = mq.textScaler;
+    // expect_lint: prefer_dedicated_media_query_method
+    final mqviewInsets = mq.viewInsets;
+    // expect_lint: prefer_dedicated_media_query_method
+    final mqviewPadding = mq.viewPadding.bottom;
+
     // expect_lint: prefer_dedicated_media_query_method
     final accessibleNavigation = MediaQuery.of(context).accessibleNavigation;
     // expect_lint: prefer_dedicated_media_query_method

--- a/example/lib/lints/flutter/prefer_dedicated_media_query_method_example.dart
+++ b/example/lib/lints/flutter/prefer_dedicated_media_query_method_example.dart
@@ -1,6 +1,6 @@
-// ignore_for_file: unused_local_variable, deprecated_member_use, max_lines_for_function
+// ignore_for_file: unused_local_variable, deprecated_member_use, max_lines_for_function, max_lines_for_file
 
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 
 class Example extends StatelessWidget {
   const Example({super.key});
@@ -91,6 +91,15 @@ class Example extends StatelessWidget {
     // expect_lint: prefer_dedicated_media_query_method
     final viewPadding = MediaQuery.of(context).viewPadding;
 
-    return const Placeholder();
+    return Scaffold(
+      body: Container(
+        // expect_lint: prefer_dedicated_media_query_method
+        height: mq.size.height,
+      ),
+    );
+  }
+
+  void fn(MediaQueryData mq) {
+    final size = mq.size;
   }
 }

--- a/lib/src/lints/flutter/prefer_dedicated_media_query_method.dart
+++ b/lib/src/lints/flutter/prefer_dedicated_media_query_method.dart
@@ -8,6 +8,7 @@ import 'package:custom_lint_builder/custom_lint_builder.dart';
 import '../../utils/constants.dart';
 import '../../utils/pubspec_extensions.dart';
 import '../../utils/string_extensions.dart';
+import '../../utils/type_checker.dart';
 
 const List<String> _properties = [
   'accessibleNavigation',
@@ -56,11 +57,6 @@ class PreferDedicatedMediaQueryMethod extends DartLintRule {
 
     context.registry.addPrefixedIdentifier((node) {
       final targetType = node.prefix.staticType;
-
-      const mediaQueryDataChecker = TypeChecker.fromName(
-        'MediaQueryData',
-        packageName: 'flutter',
-      );
 
       if (targetType == null ||
           !mediaQueryDataChecker.isExactlyType(targetType)) return;

--- a/lib/src/lints/flutter/prefer_dedicated_media_query_method.dart
+++ b/lib/src/lints/flutter/prefer_dedicated_media_query_method.dart
@@ -1,4 +1,5 @@
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/error/error.dart';
 import 'package:analyzer/error/listener.dart';
 import 'package:analyzer_plugin/utilities/range_factory.dart';
@@ -63,6 +64,11 @@ class PreferDedicatedMediaQueryMethod extends DartLintRule {
 
       if (targetType == null ||
           !mediaQueryDataChecker.isExactlyType(targetType)) return;
+
+      /// Lint should only work if the mediaQueryData variable is declared locally.
+      if (node.prefix.staticElement! is! LocalVariableElement) {
+        return;
+      }
 
       final propertyName = node.identifier.name;
       if (!_properties.contains(propertyName)) return;

--- a/lib/src/lints/flutter/prefer_dedicated_media_query_method.dart
+++ b/lib/src/lints/flutter/prefer_dedicated_media_query_method.dart
@@ -66,7 +66,7 @@ class PreferDedicatedMediaQueryMethod extends DartLintRule {
           !mediaQueryDataChecker.isExactlyType(targetType)) return;
 
       /// Lint should only work if the mediaQueryData variable is declared locally.
-      if (node.prefix.staticElement! is! LocalVariableElement) {
+      if (node.prefix.staticElement is! LocalVariableElement) {
         return;
       }
 

--- a/lib/src/lints/flutter/prefer_dedicated_media_query_method.dart
+++ b/lib/src/lints/flutter/prefer_dedicated_media_query_method.dart
@@ -39,9 +39,8 @@ class PreferDedicatedMediaQueryMethod extends DartLintRule {
 
   static const _code = LintCode(
     name: name,
-    problemMessage:
-        'Using MediaQuery.of(context).{0} will cause unnecessary rebuilds.',
-    correctionMessage: 'Consider using MediaQuery.{1}(context) instead.',
+    problemMessage: 'Using {0} will cause unnecessary rebuilds.',
+    correctionMessage: 'Consider using {1} instead.',
     url: '$docUrl#${PreferDedicatedMediaQueryMethod.name}',
     errorSeverity: ErrorSeverity.INFO,
   );
@@ -53,6 +52,29 @@ class PreferDedicatedMediaQueryMethod extends DartLintRule {
     CustomLintContext context,
   ) {
     if (!context.pubspec.isFlutterProject) return;
+
+    context.registry.addPrefixedIdentifier((node) {
+      final initializer = node;
+
+      final typeName = initializer.prefix.staticType
+          ?.getDisplayString(withNullability: false);
+      if (typeName != 'MediaQueryData') return;
+
+      final propertyName = initializer.identifier.name;
+      if (!_properties.contains(propertyName)) return;
+
+      final actual = initializer.toString();
+      final expected = 'MediaQuery.${propertyName}Of(context)';
+
+      reporter.reportErrorForNode(
+        code,
+        node,
+        [
+          actual,
+          expected,
+        ],
+      );
+    });
 
     context.registry.addPropertyAccess((node) {
       final propertyName = node.propertyName.name;
@@ -77,8 +99,8 @@ class PreferDedicatedMediaQueryMethod extends DartLintRule {
         code,
         node,
         [
-          propertyName,
-          newMethodName,
+          'MediaQuery.of(context).$propertyName',
+          'MediaQuery.$newMethodName()',
         ],
       );
     });
@@ -97,6 +119,30 @@ class _ReplaceWithDedicatedMethod extends DartFix {
     AnalysisError analysisError,
     List<AnalysisError> others,
   ) {
+    context.registry.addPrefixedIdentifier((node) {
+      if (!analysisError.sourceRange.intersects(node.sourceRange)) return;
+
+      final typeName =
+          node.prefix.staticType?.getDisplayString(withNullability: false);
+      if (typeName != 'MediaQueryData') return;
+
+      final methodName = node.identifier.name;
+
+      final expected = 'MediaQuery.${methodName}Of(context)';
+
+      final changeBuilder = reporter.createChangeBuilder(
+        message: 'Use $expected',
+        priority: 80,
+      );
+
+      changeBuilder.addDartFileEdit((builder) {
+        builder.addSimpleReplacement(
+          node.sourceRange,
+          expected,
+        );
+      });
+    });
+
     context.registry.addPropertyAccess((node) {
       if (!analysisError.sourceRange.intersects(node.sourceRange)) return;
 

--- a/lib/src/utils/type_checker.dart
+++ b/lib/src/utils/type_checker.dart
@@ -84,6 +84,11 @@ const mediaQueryChecker = TypeChecker.fromName(
   packageName: 'flutter',
 );
 
+const mediaQueryDataChecker = TypeChecker.fromName(
+  'MediaQueryData',
+  packageName: 'flutter',
+);
+
 const animationControllerChecker = TypeChecker.fromName(
   'AnimationController',
   packageName: 'flutter',


### PR DESCRIPTION
# Description

The current `prefer_dedicated_media_query_method` lint only works for direct MediaQuery.of(context).property access. For cases like these, it does not work.

```dart
final mq = MediaQuery.of(context);
final size = mq.size;
```

So I have implemented the solution using the context.registry.addPrefixedIdentifier() for both link and fix.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I have read the [CONTRIBUTING.md][contributing_link] document.
- [x] I have performed a self-review of my code.
- [ ] I have linked the issue ticket in the description.
- [ ] I have made the necessary changes to the documentation.
- [x] I have checked the formatting with `dart format .`
- [x] I have analyzed my code with `dart analyze .`
- [x] I have run `dart run custom_lint example` to check for any custom linting issues.

<!-- Links -->

[contributing_link]: https://github.com/charlescyt/pyramid_lint/blob/main/CONTRIBUTING.md
