### PR TITLE
Check for ChangeNotifier super class instead of explicit controllers'…

### DIFF
--- a/example/lib/lints/flutter/proper_controller_dispose_example.dart
+++ b/example/lib/lints/flutter/proper_controller_dispose_example.dart
@@ -1,6 +1,12 @@
 // ignore_for_file: unused_field, avoid_multiple_declarations_per_line
 
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
+
+class _CustomController extends ChangeNotifier {}
+
+class _CustomCounterController extends ValueNotifier<int> {
+  _CustomCounterController() : super(0);
+}
 
 class Example extends StatefulWidget {
   const Example({super.key});
@@ -36,6 +42,22 @@ class _Example2State extends State<Example2>
   // The lint is triggered here because _controller2 is not disposed.
   // expect_lint: proper_controller_dispose
   late AnimationController _controller1, _controller2;
+  // expect_lint: proper_controller_dispose
+  late final ScrollController _scrollController;
+  // expect_lint: proper_controller_dispose
+  late final PageController _pageController;
+  // expect_lint: proper_controller_dispose
+  late final TabController _tabController;
+  // expect_lint: proper_controller_dispose
+  late final SearchController _searchController;
+  // expect_lint: proper_controller_dispose
+  late final UndoHistoryController _undoHistoryController;
+
+  // It also works for custom controllers
+  // expect_lint: proper_controller_dispose
+  late final _CustomController _customController;
+  // expect_lint: proper_controller_dispose
+  late final _CustomCounterController _customCounterController;
 
   @override
   void initState() {

--- a/lib/src/lints/flutter/proper_controller_dispose.dart
+++ b/lib/src/lints/flutter/proper_controller_dispose.dart
@@ -41,9 +41,11 @@ class ProperControllerDispose extends DartLintRule {
       final controllerDeclarations = fieldDeclarations
           .where((e) {
             final type = e.fields.type?.type;
-            if (type != null &&
-                disposableControllerChecker.isExactlyType(type)) {
-              return true;
+            if (type != null) {
+              if (disposableControllerChecker.isExactlyType(type) ||
+                  changeNotifierChecker.isSuperTypeOf(type)) {
+                return true;
+              }
             }
 
             if (type == null) {
@@ -51,10 +53,14 @@ class ProperControllerDispose extends DartLintRule {
               if (variableDeclarations.length == 1) {
                 final variableDeclaration = variableDeclarations.first;
                 final initializer = variableDeclaration.initializer;
-                if (initializer is InstanceCreationExpression &&
-                    disposableControllerChecker
-                        .isExactlyType(initializer.staticType!)) {
-                  return true;
+
+                if (initializer is InstanceCreationExpression) {
+                  final staticType = initializer.staticType!;
+
+                  if (disposableControllerChecker.isExactlyType(staticType) ||
+                      changeNotifierChecker.isSuperTypeOf(staticType)) {
+                    return true;
+                  }
                 }
               }
             }

--- a/lib/src/utils/type_checker.dart
+++ b/lib/src/utils/type_checker.dart
@@ -124,14 +124,14 @@ const undoHistoryControllerChecker = TypeChecker.fromName(
   packageName: 'flutter',
 );
 
+const changeNotifierChecker = TypeChecker.fromName(
+  'ChangeNotifier',
+  packageName: 'flutter',
+);
+
+// Controllers that do not extend ChangeNotifier class
 const disposableControllerChecker = TypeChecker.any(
   [
     animationControllerChecker,
-    pageControllerChecker,
-    scrollControllerChecker,
-    searchControllerChecker,
-    tabControllerChecker,
-    textEditingControllerChecker,
-    undoHistoryControllerChecker,
   ],
 );


### PR DESCRIPTION
# Description

The current `proper_controller_dispose` lint only works for a few explicitly defined controller types. In Flutter most of the Controller classes extend the ChangeNotifier class. So we can check if the type has a ChangeNotifier supertype. By doing so we can support many more controller types even the custom controllers without explicitly defining each one. 

There's one commonly used class 'AnimationController' which does not extend the ChangeNotifier so we need to check that class explicitly.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I have read the [CONTRIBUTING.md][contributing_link] document.
- [x] I have performed a self-review of my code.
- [ ] I have linked the issue ticket in the description.
- [ ] I have made the necessary changes to the documentation.
- [x] I have checked the formatting with `dart format .`
- [x] I have analyzed my code with `dart analyze .`
- [x] I have run `dart run custom_lint example` to check for any custom linting issues.

<!-- Links -->

[contributing_link]: https://github.com/charlescyt/pyramid_lint/blob/main/CONTRIBUTING.md
