### PR TITLE
Fixes boolean_prefix_lint showing for overriden methods

### DIFF
--- a/example/lib/lints/dart/boolean_prefix_example.dart
+++ b/example/lib/lints/dart/boolean_prefix_example.dart
@@ -14,7 +14,16 @@ class Point {
   bool get origin => x == 0 && y == 0;
 
   // expect_lint: boolean_prefix
-  bool samePoint(Point other) => x == other.x && y == other.y;
+  bool samePoint(covariant Point other) => x == other.x && y == other.y;
+}
+
+class Point3D extends Point {
+  final double z;
+
+  const Point3D(super.x, super.y, this.z);
+
+  @override
+  bool samePoint(Point3D other) => super.samePoint(other) && z == other.z;
 }
 
 // expect_lint: boolean_prefix

--- a/lib/src/lints/dart/boolean_prefix.dart
+++ b/lib/src/lints/dart/boolean_prefix.dart
@@ -74,7 +74,9 @@ class BooleanPrefix extends DartLintRule {
     context.registry.addMethodDeclaration((node) {
       final returnType = node.returnType?.type;
       if (returnType == null || !returnType.isDartCoreBool) return;
-      if (node.declaredElement?.hasOverride ?? true) return;
+
+      final element = node.declaredElement;
+      if (element == null || element.hasOverride) return;
 
       final name = node.name.lexeme;
       if (isNameValid(name)) return;

--- a/lib/src/lints/dart/boolean_prefix.dart
+++ b/lib/src/lints/dart/boolean_prefix.dart
@@ -74,6 +74,7 @@ class BooleanPrefix extends DartLintRule {
     context.registry.addMethodDeclaration((node) {
       final returnType = node.returnType?.type;
       if (returnType == null || !returnType.isDartCoreBool) return;
+      if (node.declaredElement?.hasOverride ?? true) return;
 
       final name = node.name.lexeme;
       if (isNameValid(name)) return;


### PR DESCRIPTION
# Description

Handle the case when the method is a overriden method. We don't need to show lint on overriden methods.

Fixes boolean_prefix_lint showing for overriden methods

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I have read the [CONTRIBUTING.md][contributing_link] document.
- [x] I have performed a self-review of my code.
- [ ] I have linked the issue ticket in the description.
- [ ] I have made the necessary changes to the documentation.
- [x] I have checked the formatting with `dart format .`
- [x] I have analyzed my code with `dart analyze .`
- [x] I have run `dart run custom_lint example` to check for any custom linting issues.

<!-- Links -->

[contributing_link]: https://github.com/charlescyt/pyramid_lint/blob/main/CONTRIBUTING.md
