### PR TITLE
Fixes prefer_async_callback showing for Future type that has no type param or other than void

### DIFF
--- a/example/lib/lints/flutter/prefer_async_callback_example.dart
+++ b/example/lib/lints/flutter/prefer_async_callback_example.dart
@@ -3,7 +3,19 @@ import 'package:flutter/foundation.dart' show AsyncCallback;
 typedef A = AsyncCallback;
 // expect_lint: prefer_async_callback
 typedef B = Future<void> Function();
+typedef B2 = Future<int> Function();
+// ignore: strict_raw_type
+typedef B3 = Future Function();
 // expect_lint: prefer_async_callback
 typedef C = Future<void> Function()?;
 typedef D = Future<void> Function(int index);
 typedef E = Future<void> Function({required int index});
+
+Future<T?> thenOrNull<T>(Future<T> Function() cb) async {
+  try {
+    return await cb();
+    // ignore: avoid_catches_without_on_clauses
+  } catch (_) {
+    return null;
+  }
+}

--- a/lib/src/lints/flutter/prefer_async_callback.dart
+++ b/lib/src/lints/flutter/prefer_async_callback.dart
@@ -1,5 +1,7 @@
+import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/error/error.dart';
 import 'package:analyzer/error/listener.dart';
+import 'package:analyzer/src/dart/ast/ast.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 
 import '../../utils/constants.dart';
@@ -36,6 +38,15 @@ class PreferAsyncCallback extends DartLintRule {
 
       final typeParameters = node.typeParameters?.typeParameters;
       if (typeParameters != null) return;
+
+      final returnTypeArgs =
+          (node.returnType! as NamedType).typeArguments?.arguments;
+      switch (returnTypeArgs) {
+        case [final NamedType type] when type.type is VoidType:
+          break;
+        case _:
+          return;
+      }
 
       reporter.reportErrorForNode(code, node);
     });


### PR DESCRIPTION
# Description

In prefer_async_callback lint we should handle cases when the Future has no type arg or other than void. 

Fixes prefer_async_callback showing for Future type that has no type param or other than void

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I have read the [CONTRIBUTING.md][contributing_link] document.
- [x] I have performed a self-review of my code.
- [ ] I have linked the issue ticket in the description.
- [ ] I have made the necessary changes to the documentation.
- [x] I have checked the formatting with `dart format .`
- [x] I have analyzed my code with `dart analyze .`
- [x] I have run `dart run custom_lint example` to check for any custom linting issues.

<!-- Links -->

[contributing_link]: https://github.com/charlescyt/pyramid_lint/blob/main/CONTRIBUTING.md
