### PR TITLE
Handled the type element null case

### DIFF
--- a/packages/pyramid_lint/lib/src/assists/flutter/wrap_with_stack.dart
+++ b/packages/pyramid_lint/lib/src/assists/flutter/wrap_with_stack.dart
@@ -19,8 +19,8 @@ class WrapWithStack extends DartAssist {
       final sourceRange = node.keywordAndConstructorNameSourceRange;
       if (!sourceRange.covers(target)) return;
 
-      final type = node.staticType;
-      if (type == null || !widgetChecker.isSuperTypeOf(type)) return;
+      final typeElement = node.staticType?.element;
+      if (typeElement == null || !widgetChecker.isSuperOf(typeElement)) return;
 
       final changeBuilder = reporter.createChangeBuilder(
         message: 'Wrap with Stack',


### PR DESCRIPTION
# Description

As I used the lint in a production application, I got frequent `Null check operator used on a null value` errors in the custom.log file. That was due to this code in the `TypeChecker` class.

```dart

/// Returns `true` if representing a super type of [staticType].
///
/// This only takes into account the *extends* hierarchy. If you wish
/// to check mixins and interfaces, use [isAssignableFromType].
bool isSuperTypeOf(DartType staticType) => isSuperOf(staticType.element!);
```

Sometimes staticType.element is null (Documentation says when the Ast is unresolved but I'm not sure). For now, I have checked the element null case only in the wrap_with_stack assist. But the error is thrown in almost every lint. Need some research on this issue though. 

error log: 
```
[WrapWithStack] 2024-01-15T14:15:52.836429 Plugin WrapWithStack threw while analyzing /home/sam/work_projects/flutter/vidaksh_mobile/lib/src/modules/home/presentation/pages/about_us_page.dart:
[WrapWithStack] 2024-01-15T14:15:52.836429 Null check operator used on a null value
[WrapWithStack] 2024-01-15T14:15:52.836429 #0      TypeChecker.isSuperTypeOf (package:custom_lint_core/src/type_checker.dart:224:74)
[WrapWithStack] 2024-01-15T14:15:52.836429 #1      WrapWithStack.run.<anonymous closure> (package:pyramid_lint/src/assists/flutter/wrap_with_stack.dart:29:42)
[WrapWithStack] 2024-01-15T14:15:52.836429 #2      _rootRunUnary (dart:async/zone.dart:1415:13)
[WrapWithStack] 2024-01-15T14:15:52.836429 #3      _CustomZone.runUnary (dart:async/zone.dart:1308:19)
[WrapWithStack] 2024-01-15T14:15:52.836429 #4      LinterVisitor._runSubscriptions (package:custom_lint_core/src/node_lint_visitor.g.dart:29:27)
[WrapWithStack] 2024-01-15T14:15:52.836429 #5      LinterVisitor.visitInstanceCreationExpression (package:custom_lint_core/src/node_lint_visitor.g.dart:609:5)
[WrapWithStack] 2024-01-15T14:15:52.836429 #6      InstanceCreationExpressionImpl.accept (package:analyzer/src/dart/ast/ast.dart:10462:15)
[WrapWithStack] 2024-01-15T14:15:52.836429 #7      NodeListImpl.accept (package:analyzer/src/dart/ast/ast.dart:12998:20)
[WrapWithStack] 2024-01-15T14:15:52.836429 #8      ArgumentListImpl.visitChildren (package:analyzer/src/dart/ast/ast.dart:510:16)
```



## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I have read the [CONTRIBUTING.md][contributing_link] document.
- [x] I have performed a self-review of my code.
- [ ] I have linked the issue ticket in the description.
- [ ] I have made the necessary changes to the documentation.
- [x] I have checked the formatting with `dart format .`
- [x] I have analyzed my code with `dart analyze .`
- [x] I have run `dart run custom_lint example` to check for any custom linting issues.

<!-- Links -->

[contributing_link]: https://github.com/charlescyt/pyramid_lint/blob/main/CONTRIBUTING.md
