### PR TITLE
Change avoid_returning_widgets to ignore static and overridden methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- `avoid_returning_widgets` now ignores static and overridden methods and supports `ignored_method_names` option. ([#24](https://github.com/charlescyt/pyramid_lint/pull/24))
+
 ## 1.3.0 - 2024-01-15
 
 ### Added

--- a/docs/flutter-lints/avoid_returning_widgets.mdx
+++ b/docs/flutter-lints/avoid_returning_widgets.mdx
@@ -1,10 +1,14 @@
 # avoid_returning_widgets
 
 - Severity: info ℹ️
+- Options:
+  - ignored_method_names: `List<String>`
 
 ## Details
 
 **Avoid** returning widgets from methods.
+
+<Info> Static and overridden methods are ignored. </Info>
 
 <YouTube id="IOyq-eTRhvo" />
 
@@ -61,4 +65,13 @@ To enable the `avoid_returning_widgets` rule, add `avoid_returning_widgets` unde
 custom_lint:
   rules:
     - avoid_returning_widgets
+```
+
+To configure the list of ignored method names, add a list of strings to the `ignored_method_names` option:
+
+```yaml
+custom_lint:
+  rules:
+    - avoid_returning_widgets:
+        ignored_method_names: ['myMethod']
 ```

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -14,3 +14,5 @@ custom_lint:
       valid_prefixes: ["at"]
     - avoid_abbreviations_in_doc_comments:
       abbreviations: ["approx."]
+    - avoid_returning_widgets:
+      ignored_method_names: ['myMethod']

--- a/example/lib/lints/flutter/avoid_returning_widgets_example.dart
+++ b/example/lib/lints/flutter/avoid_returning_widgets_example.dart
@@ -46,3 +46,22 @@ Widget buildWidget() => const Placeholder();
 
 // expect_lint: avoid_returning_widgets
 Widget get myWidget => const Placeholder();
+
+class MyInheritedWidget extends InheritedWidget {
+  const MyInheritedWidget({
+    super.key,
+    required super.child,
+  });
+
+  @override
+  bool updateShouldNotify(MyInheritedWidget oldWidget) => false;
+
+  // Static methods are ignored.
+  static MyInheritedWidget? of(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<MyInheritedWidget>();
+  }
+}
+
+Widget myMethod() {
+  return const Placeholder();
+}

--- a/lib/pyramid_lint.dart
+++ b/lib/pyramid_lint.dart
@@ -75,7 +75,7 @@ class _PyramidLinter extends PluginBase {
         const PreferUnderscoreForUnusedCallbackParameters(),
         const UnnecessaryNullableReturnType(),
         // Flutter lints
-        const AvoidReturningWidgets(),
+        AvoidReturningWidgets.fromConfigs(configs),
         const AvoidSingleChildInFlex(),
         const AvoidWidgetStatePublicMembers(),
         const PreferAsyncCallback(),


### PR DESCRIPTION
# Description

- Change `avoid_returning_widgets` to ignore static and overridden method
- Add `ignored_method_names` options

Fixes #22

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I have read the [CONTRIBUTING.md][contributing_link] document.
- [x] I have performed a self-review of my code.
- [x] I have linked the issue ticket in the description.
- [x] I have made the necessary changes to the documentation.
- [x] I have checked the formatting with `dart format .`
- [x] I have analyzed my code with `dart analyze .`
- [x] I have run `dart run custom_lint example` to check for any custom linting issues.

<!-- Links -->

[contributing_link]: https://github.com/charlescyt/pyramid_lint/blob/main/CONTRIBUTING.md
