### PR TITLE
Fix incorrect quick fix for prefer_iterable_first and prefer_iterable_last on 2D list

### DIFF
--- a/example/lib/lints/dart/prefer_iterable_first_example.dart
+++ b/example/lib/lints/dart/prefer_iterable_first_example.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: unused_local_variable
+
 const numbers = [1, 2, 3];
 
 // expect_lint: prefer_iterable_first
@@ -5,3 +7,14 @@ final a = numbers[0];
 
 // expect_lint: prefer_iterable_first
 final b = numbers.elementAt(0);
+
+final listOfLists = [
+  [1, 2, 3],
+  [4, 5, 6],
+  [7, 8, 9],
+];
+
+void fn() {
+  // expect_lint: prefer_iterable_first
+  final value = listOfLists[0][1];
+}

--- a/example/lib/lints/dart/prefer_iterable_last_example.dart
+++ b/example/lib/lints/dart/prefer_iterable_last_example.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: unused_local_variable
+
 const numbers = [1, 2, 3];
 
 // expect_lint: prefer_iterable_last
@@ -5,3 +7,14 @@ final a = numbers[numbers.length - 1];
 
 // expect_lint: prefer_iterable_last
 final b = numbers.elementAt(numbers.length - 1);
+
+final listOfLists = [
+  [1, 2, 3],
+  [4, 5, 6],
+  [7, 8, 9],
+];
+
+void fn() {
+  // expect_lint: prefer_iterable_last
+  final value = listOfLists[listOfLists.length - 1][1];
+}

--- a/lib/src/lints/dart/prefer_iterable_first.dart
+++ b/lib/src/lints/dart/prefer_iterable_first.dart
@@ -83,7 +83,7 @@ class _ReplaceWithIterableFirst extends DartFix {
     List<AnalysisError> others,
   ) {
     context.registry.addIndexExpression((node) {
-      if (!analysisError.sourceRange.intersects(node.sourceRange)) return;
+      if (!analysisError.sourceRange.covers(node.sourceRange)) return;
 
       final changeBuilder = reporter.createChangeBuilder(
         message: 'Replace with iterable.first',
@@ -100,7 +100,7 @@ class _ReplaceWithIterableFirst extends DartFix {
     });
 
     context.registry.addMethodInvocation((node) {
-      if (!analysisError.sourceRange.intersects(node.sourceRange)) return;
+      if (!analysisError.sourceRange.covers(node.sourceRange)) return;
 
       final changeBuilder = reporter.createChangeBuilder(
         message: 'Replace with iterable.first',

--- a/lib/src/lints/dart/prefer_iterable_last.dart
+++ b/lib/src/lints/dart/prefer_iterable_last.dart
@@ -104,7 +104,7 @@ class _ReplaceWithIterableLast extends DartFix {
     List<AnalysisError> others,
   ) {
     context.registry.addIndexExpression((node) {
-      if (!analysisError.sourceRange.intersects(node.sourceRange)) return;
+      if (!analysisError.sourceRange.covers(node.sourceRange)) return;
 
       final changeBuilder = reporter.createChangeBuilder(
         message: 'Replace with iterable.last',
@@ -121,7 +121,7 @@ class _ReplaceWithIterableLast extends DartFix {
     });
 
     context.registry.addMethodInvocation((node) {
-      if (!analysisError.sourceRange.intersects(node.sourceRange)) return;
+      if (!analysisError.sourceRange.covers(node.sourceRange)) return;
 
       final changeBuilder = reporter.createChangeBuilder(
         message: 'Replace with iterable.last',


### PR DESCRIPTION
# Description

Fixes #31 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I have read the [CONTRIBUTING.md][contributing_link] document.
- [x] I have performed a self-review of my code.
- [x] I have linked the issue ticket in the description.
- [x] I have made the necessary changes to the documentation.
- [x] I have checked the formatting with `dart format .`
- [x] I have analyzed my code with `dart analyze .`
- [x] I have run `dart run custom_lint example` to check for any custom linting issues.

<!-- Links -->

[contributing_link]: https://github.com/charlescyt/pyramid_lint/blob/main/CONTRIBUTING.md
