### PR TITLE
Improve wrap_with_layout_builder

### DIFF
--- a/docs/flutter-assists/wrap_with_layout_builder.mdx
+++ b/docs/flutter-assists/wrap_with_layout_builder.mdx
@@ -2,4 +2,8 @@
 
 Wrap the selected widget with a LayoutBuilder.
 
+<info> This assist is only available if the selected widget is not a LayoutBuilder. </info>
+
+<info> This assist is only available if the selected widget is not already wrapped with a LayoutBuilder. </info>
+
 ![wrap_with_layout_builder](https://raw.githubusercontent.com/charlescyt/pyramid_lint/main/docs/assets/wrap_with_layout_builder.gif)

--- a/packages/pyramid_lint/CHANGELOG.md
+++ b/packages/pyramid_lint/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- `wrap_with_layout_builder` will not be available if the selected widget is a `LayoutBuilder` or already wrapped with a `LayoutBuilder`.
+
 ## [1.4.0] - 2024-02-07
 
 ### Added
@@ -155,6 +161,7 @@
 [parlough]: https://github.com/parlough
 [imsamgarg]: https://github.com/imsamgarg
 
+[Unreleased]: https://github.com/charlescyt/pyramid_lint/compare/v1.4.0...HEAD
 [1.4.0]: https://github.com/charlescyt/pyramid_lint/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/charlescyt/pyramid_lint/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/charlescyt/pyramid_lint/compare/v1.1.0...v1.2.0

--- a/packages/pyramid_lint/lib/src/assists/flutter/wrap_with_layout_builder.dart
+++ b/packages/pyramid_lint/lib/src/assists/flutter/wrap_with_layout_builder.dart
@@ -4,6 +4,7 @@ import 'package:custom_lint_builder/custom_lint_builder.dart';
 import '../../utils/ast_node_extensions.dart';
 import '../../utils/pubspec_extension.dart';
 import '../../utils/type_checker.dart';
+import '../../utils/utils.dart';
 
 class WrapWithLayoutBuilder extends DartAssist {
   @override
@@ -21,6 +22,17 @@ class WrapWithLayoutBuilder extends DartAssist {
 
       final type = node.staticType;
       if (type == null || !widgetChecker.isSuperTypeOf(type)) return;
+
+      if (layoutBuilderChecker.isExactlyType(type)) return;
+
+      final parentWidget = findParentWidget(node);
+      if (parentWidget != null) {
+        final parentType = parentWidget.staticType;
+        if (parentType != null &&
+            layoutBuilderChecker.isExactlyType(parentType)) {
+          return;
+        }
+      }
 
       final changeBuilder = reporter.createChangeBuilder(
         message: 'Wrap with LayoutBuilder',

--- a/packages/pyramid_lint/lib/src/utils/type_checker.dart
+++ b/packages/pyramid_lint/lib/src/utils/type_checker.dart
@@ -50,6 +50,11 @@ const borderRadiusChecker = TypeChecker.fromName(
   packageName: 'flutter',
 );
 
+const layoutBuilderChecker = TypeChecker.fromName(
+  'LayoutBuilder',
+  packageName: 'flutter',
+);
+
 const flexChecker = TypeChecker.fromName(
   'Flex',
   packageName: 'flutter',

--- a/packages/pyramid_lint/lib/src/utils/utils.dart
+++ b/packages/pyramid_lint/lib/src/utils/utils.dart
@@ -3,6 +3,8 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/element/element.dart';
 
+import 'type_checker.dart';
+
 bool isZeroExpression(Expression e) {
   if (e is IntegerLiteral) return e.value == 0;
   if (e is DoubleLiteral) return e.value == 0.0;
@@ -34,4 +36,17 @@ AstNode? getAstNodeFromElement(Element element) {
       parsedLibraryResult.getElementDeclaration(element);
 
   return elementDeclarationResult?.node;
+}
+
+InstanceCreationExpression? findParentWidget(InstanceCreationExpression expr) {
+  final parentExpr =
+      expr.parent?.thisOrAncestorOfType<InstanceCreationExpression>();
+  if (parentExpr == null) return null;
+
+  final parentType = parentExpr.staticType;
+  if (parentType == null || !widgetChecker.isSuperTypeOf(parentType)) {
+    return null;
+  }
+
+  return parentExpr;
 }

--- a/packages/pyramid_lint_test/test/assists/flutter/wrap_with_layout_builder/wrap_with_layout_builder.dart
+++ b/packages/pyramid_lint_test/test/assists/flutter/wrap_with_layout_builder/wrap_with_layout_builder.dart
@@ -5,6 +5,12 @@ class A extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container();
+    return LayoutBuilder(
+      builder: (_, __) {
+        return const Center(
+          child: Placeholder(),
+        );
+      },
+    );
   }
 }

--- a/packages/pyramid_lint_test/test/assists/flutter/wrap_with_layout_builder/wrap_with_layout_builder.diff
+++ b/packages/pyramid_lint_test/test/assists/flutter/wrap_with_layout_builder/wrap_with_layout_builder.diff
@@ -1,12 +1,12 @@
 Message: `Wrap with LayoutBuilder`
 Priority: 29
-Diff for file `test/assists/flutter/wrap_with_layout_builder/wrap_with_layout_builder.dart:8`:
+Diff for file `test/assists/flutter/wrap_with_layout_builder/wrap_with_layout_builder.dart:11`:
 ```
-  @override
-  Widget build(BuildContext context) {
--     return Container();
-+     return LayoutBuilder(builder: (context, constraints) { return Container(); },);
-  }
-}
+      builder: (_, __) {
+        return const Center(
+-           child: Placeholder(),
++           child: LayoutBuilder(builder: (context, constraints) { return Placeholder(); },),
+        );
+      },
 ```
 ---

--- a/packages/pyramid_lint_test/test/assists/flutter/wrap_with_layout_builder/wrap_with_layout_builder_test.dart
+++ b/packages/pyramid_lint_test/test/assists/flutter/wrap_with_layout_builder/wrap_with_layout_builder_test.dart
@@ -19,10 +19,24 @@ void main() {
       );
 
       final changes = [
-        // Container
+        // LayoutBuilder
         ...await assist.testRun(
           result,
           const SourceRange(166, 0),
+          pubspec: pubspec,
+        ),
+
+        // Center
+        ...await assist.testRun(
+          result,
+          const SourceRange(225, 0),
+          pubspec: pubspec,
+        ),
+
+        // Placeholder
+        ...await assist.testRun(
+          result,
+          const SourceRange(252, 0),
           pubspec: pubspec,
         ),
       ];


### PR DESCRIPTION
Improve `wrap_with_layout_builder` such that it will not be available if the selected widget is a `LayoutBuilder` or already wrapped with a `LayoutBuilder`.