### PR TITLE
Fix false positive for avoid_nested_if

### DIFF
--- a/packages/pyramid_lint/CHANGELOG.md
+++ b/packages/pyramid_lint/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - **BREAKING**: All lints are now disabled by default. You need to enable them in your `analysis_options.yaml` file.
 - Pump the minimum `custom_lint_builder` version to 0.6.2.
+- Fix false positive for `avoid_nested_if` when the if statement is a else if statement.
 
 ## [1.5.0] - 2024-02-14
 

--- a/packages/pyramid_lint/lib/src/lints/dart/avoid_nested_if.dart
+++ b/packages/pyramid_lint/lib/src/lints/dart/avoid_nested_if.dart
@@ -5,9 +5,9 @@ import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'package:meta/meta.dart' show immutable;
 
 import '../../pyramid_lint_rule.dart';
-import '../../utils/ast_node_extensions.dart';
 import '../../utils/constants.dart';
 import '../../utils/typedef.dart';
+import '../../utils/visitors.dart';
 
 @immutable
 class AvoidNestedIfOptions {
@@ -61,10 +61,12 @@ class AvoidNestedIf extends PyramidLintRule<AvoidNestedIfOptions> {
     CustomLintContext context,
   ) {
     context.registry.addIfStatement((node) {
-      final parentIf = node.parent?.thisOrAncestorOfType<IfStatement>();
-      if (parentIf != null) return;
+      final ifStatements = <IfStatement>[];
+      final visitor = RecursiveIfStatementVisitor(
+        onVisitIfStatement: ifStatements.add,
+      );
+      node.thenStatement.visitChildren(visitor);
 
-      final ifStatements = node.childrenIfStatements;
       if (ifStatements.length < options.params.maxNestingLevel) return;
 
       reporter.reportErrorForNode(code, node);

--- a/packages/pyramid_lint_test/test/lints/dart/avoid_nested_if.dart
+++ b/packages/pyramid_lint_test/test/lints/dart/avoid_nested_if.dart
@@ -1,11 +1,21 @@
-// ignore_for_file: literal_only_boolean_expressions, avoid_empty_blocks, dead_code
+// ignore_for_file: literal_only_boolean_expressions, avoid_empty_blocks
 
-void example() {
+void fn() {
   // expect_lint: avoid_nested_if
   if (true) {
     if (true) {
-      if (true) {
-      } else {}
-    } else {}
-  } else {}
+      if (true) {}
+    }
+  }
+}
+
+void fn2(int a) {
+  if (a == 1) {
+  } else if (a == 2) {
+    // expect_lint: avoid_nested_if
+  } else if (a == 3) {
+    if (true) {
+      if (true) {}
+    }
+  } else if (a == 4) {}
 }


### PR DESCRIPTION
# Description

Fix false positive for `avoid_nested_if` when the if statement is a else if statement.

Fix #43 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I have read the [CONTRIBUTING.md][contributing] document.
- [x] I have performed a self-review of my code.
- [x] I have linked the issue ticket in the description (if applicable).
- [x] I have made the necessary changes to the documentation.
- [x] I have formatted my code with `dart format .` in both `packages/pyramid_lint/` and `packages/pyramid_lint_test/`.
- [x] I have analyzed my code with `dart analyze .` in both `packages/pyramid_lint/` and `packages/pyramid_lint_test/`.
- [x] I have analyzed my code with `dart run custom_lint .` or `custom_lint .`(if you have `custom_lint` installed globally) in `packages/pyramid_lint_test/`.
- [x] I have tested my code with `dart test` in `packages/pyramid_lint_test/`.

<!-- Links -->

[contributing]: https://github.com/charlescyt/pyramid_lint/blob/main/CONTRIBUTING.md
