### PR TITLE
Update avoid_public_members_in_states

### DIFF
--- a/docs/flutter-lints/avoid_public_members_in_states.mdx
+++ b/docs/flutter-lints/avoid_public_members_in_states.mdx
@@ -6,7 +6,9 @@
 
 ## Details
 
-**AVOID** declaring public members in widget state classes.
+**AVOID** declaring public fields and methods in widget state classes.
+
+<Info> Public fields and methods with `@visibleForTesting` annotations are ignored. </Info>
 
 ```dart title="Bad"
 class _MyWidgetState extends State<MyWidget> {

--- a/packages/pyramid_lint/CHANGELOG.md
+++ b/packages/pyramid_lint/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- `avoid_public_members_in_states` now ignores public fields and methods with `@visibleForTesting` annotations.
+
 ## [2.0.0] - 2024-03-06
 
 ### Added

--- a/packages/pyramid_lint/lib/src/lints/flutter/avoid_public_members_in_states.dart
+++ b/packages/pyramid_lint/lib/src/lints/flutter/avoid_public_members_in_states.dart
@@ -51,6 +51,10 @@ class AvoidPublicMembersInStates extends PyramidLintRule {
           classMember.metadata.any((e) => e.name.name == 'override');
       if (hasOverrideAnnotation) return;
 
+      final hasVisibleForTestingAnnotation =
+          classMember.metadata.any((e) => e.name.name == 'visibleForTesting');
+      if (hasVisibleForTestingAnnotation) return;
+
       switch (classMember) {
         case final ConstructorDeclaration _:
           return;

--- a/packages/pyramid_lint/pubspec.yaml
+++ b/packages/pyramid_lint/pubspec.yaml
@@ -22,7 +22,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  analyzer: ">=6.0.0 <7.0.0"
+  analyzer: ">=6.0.0 <6.5.0"
   analyzer_plugin: ^0.11.2
   collection: ^1.17.1
   custom_lint_builder: ^0.6.2

--- a/packages/pyramid_lint_test/test/lints/flutter/avoid_widget_state_public_members.dart
+++ b/packages/pyramid_lint_test/test/lints/flutter/avoid_widget_state_public_members.dart
@@ -13,6 +13,9 @@ class _BarState extends State<Bar> {
   // expect_lint: avoid_public_members_in_states
   int publicField = 1;
 
+  @visibleForTesting
+  int publicFieldWithVisibleForTestingAnnotation = 1;
+
   int _privateField = 0;
 
   // expect_lint: avoid_public_members_in_states
@@ -30,6 +33,9 @@ class _BarState extends State<Bar> {
 
   // expect_lint: avoid_public_members_in_states
   void publicMethod() {}
+
+  @visibleForTesting
+  void publicMethodWithVisibleForTestingAnnotation() {}
 
   void _privateMethod() {}
 }


### PR DESCRIPTION
# Description

Update `avoid_public_members_in_states` to ignore public fields and methods with `@visibleForTesting` annotations.

Closes #46.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I have read the [CONTRIBUTING.md][contributing] document.
- [x] I have performed a self-review of my code.
- [x] I have linked the issue ticket in the description (if applicable).
- [x] I have made the necessary changes to the documentation.
- [x] I have formatted my code with `dart format .` in both `packages/pyramid_lint/` and `packages/pyramid_lint_test/`.
- [x] I have analyzed my code with `dart analyze .` in both `packages/pyramid_lint/` and `packages/pyramid_lint_test/`.
- [x] I have analyzed my code with `dart run custom_lint .` or `custom_lint .`(if you have `custom_lint` installed globally) in `packages/pyramid_lint_test/`.
- [x] I have tested my code with `dart test` in `packages/pyramid_lint_test/`.

<!-- Links -->

[contributing]: https://github.com/charlescyt/pyramid_lint/blob/main/CONTRIBUTING.md
