### PR TITLE
Fix false positive on cascade notation for dispose_controllers

### DIFF
--- a/packages/pyramid_lint/CHANGELOG.md
+++ b/packages/pyramid_lint/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `avoid_public_members_in_states` now ignores public fields and methods with `@visibleForTesting` annotations.
 
+### Fixed
+
+- Fix false positive for `dispose_controllers` when dispose is already called via [cascade notation](https://dart.dev/language/operators#cascade-notation).
+
 ## [2.0.0] - 2024-03-06
 
 ### Added

--- a/packages/pyramid_lint/lib/src/lints/flutter/dispose_controllers.dart
+++ b/packages/pyramid_lint/lib/src/lints/flutter/dispose_controllers.dart
@@ -231,18 +231,18 @@ Iterable<String> _getDisposeStatementTargetNames(
 String? _getTargetNameOfDisposeMethodInvocation(
   ExpressionStatement expressionStatement,
 ) {
-  if (expressionStatement.expression is CascadeExpression) {
-    final cascadeExpression =
-        expressionStatement.expression as CascadeExpression;
-
+  if (expressionStatement.expression
+      case final CascadeExpression cascadeExpression) {
     for (final section in cascadeExpression.cascadeSections) {
       if (section is MethodInvocation && section.methodName.name == 'dispose') {
-        return cascadeExpression.target.toString();
+        if (cascadeExpression.target
+            case final SimpleIdentifier simpleIdentifier) {
+          return simpleIdentifier.name;
+        }
       }
     }
-  } else if (expressionStatement.expression is MethodInvocation) {
-    final methodInvocation = expressionStatement.expression as MethodInvocation;
-
+  } else if (expressionStatement.expression
+      case final MethodInvocation methodInvocation) {
     final target = methodInvocation.target;
     if (target is! SimpleIdentifier) return null;
 

--- a/packages/pyramid_lint/lib/src/lints/flutter/dispose_controllers.dart
+++ b/packages/pyramid_lint/lib/src/lints/flutter/dispose_controllers.dart
@@ -224,20 +224,33 @@ Iterable<String> _getDisposeStatementTargetNames(
   NodeList<Statement> statements,
 ) {
   return statements.expressionStatements
-      .map((e) => e.expression)
-      .whereType<MethodInvocation>()
       .map(_getTargetNameOfDisposeMethodInvocation)
       .nonNulls;
 }
 
 String? _getTargetNameOfDisposeMethodInvocation(
-  MethodInvocation invocation,
+  ExpressionStatement expressionStatement,
 ) {
-  final target = invocation.target;
-  if (target is! SimpleIdentifier) return null;
+  if (expressionStatement.expression is CascadeExpression) {
+    final cascadeExpression =
+        expressionStatement.expression as CascadeExpression;
 
-  final methodName = invocation.methodName.name;
-  if (methodName != 'dispose') return null;
+    for (final section in cascadeExpression.cascadeSections) {
+      if (section is MethodInvocation && section.methodName.name == 'dispose') {
+        return cascadeExpression.target.toString();
+      }
+    }
+  } else if (expressionStatement.expression is MethodInvocation) {
+    final methodInvocation = expressionStatement.expression as MethodInvocation;
 
-  return target.name;
+    final target = methodInvocation.target;
+    if (target is! SimpleIdentifier) return null;
+
+    final methodName = methodInvocation.methodName.name;
+    if (methodName != 'dispose') return null;
+
+    return target.name;
+  }
+
+  return null;
 }

--- a/packages/pyramid_lint_test/test/lints/flutter/dispose_controllers/dispose_controllers.dart
+++ b/packages/pyramid_lint_test/test/lints/flutter/dispose_controllers/dispose_controllers.dart
@@ -89,3 +89,63 @@ class _Example2State extends State<Example2>
     return const Placeholder();
   }
 }
+
+class Example3 extends StatefulWidget {
+  const Example3({
+    super.key,
+  });
+
+  @override
+  State<Example3> createState() => _Example3State();
+}
+
+class _Example3State extends State<Example3> {
+  late final ScrollController _scrollController;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController = ScrollController();
+    _scrollController.addListener(_handleScrollChange);
+  }
+
+  @override
+  void dispose() {
+    _scrollController
+      ..removeListener(_handleScrollChange)
+      ..dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
+  }
+
+  // ignore: avoid_empty_blocks
+  void _handleScrollChange() {}
+}
+
+class Example4 extends StatefulWidget {
+  const Example4({
+    super.key,
+  });
+
+  @override
+  State<Example4> createState() => _Example4State();
+}
+
+class _Example4State extends State<Example4> {
+  // expect_lint: dispose_controllers
+  late final ScrollController _scrollController = ScrollController();
+
+  @override
+  void dispose() {
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
+  }
+}

--- a/packages/pyramid_lint_test/test/lints/flutter/dispose_controllers/fix/dispose_controllers.dart
+++ b/packages/pyramid_lint_test/test/lints/flutter/dispose_controllers/fix/dispose_controllers.dart
@@ -89,3 +89,63 @@ class _Example2State extends State<Example2>
     return const Placeholder();
   }
 }
+
+class Example3 extends StatefulWidget {
+  const Example3({
+    super.key,
+  });
+
+  @override
+  State<Example3> createState() => _Example3State();
+}
+
+class _Example3State extends State<Example3> {
+  late final ScrollController _scrollController;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController = ScrollController();
+    _scrollController.addListener(_handleScrollChange);
+  }
+
+  @override
+  void dispose() {
+    _scrollController
+      ..removeListener(_handleScrollChange)
+      ..dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
+  }
+
+  // ignore: avoid_empty_blocks
+  void _handleScrollChange() {}
+}
+
+class Example4 extends StatefulWidget {
+  const Example4({
+    super.key,
+  });
+
+  @override
+  State<Example4> createState() => _Example4State();
+}
+
+class _Example4State extends State<Example4> {
+  // expect_lint: dispose_controllers
+  late final ScrollController _scrollController = ScrollController();
+
+  @override
+  void dispose() {
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
+  }
+}

--- a/packages/pyramid_lint_test/test/lints/flutter/dispose_controllers/fix/dispose_controllers.diff
+++ b/packages/pyramid_lint_test/test/lints/flutter/dispose_controllers/fix/dispose_controllers.diff
@@ -120,3 +120,16 @@ Diff for file `test/lints/flutter/dispose_controllers/fix/dispose_controllers.da
   }
 ```
 ---
+Message: `Dispose controller`
+Priority: 80
+Diff for file `test/lints/flutter/dispose_controllers/fix/dispose_controllers.dart:144`:
+```
+  @override
+  void dispose() {
+-     super.dispose();
++     _scrollController.dispose();
++     super.dispose();
+  }
+
+```
+---

--- a/packages/pyramid_lint_test/test/lints/flutter/dispose_controllers/fix/dispose_controllers_test.dart
+++ b/packages/pyramid_lint_test/test/lints/flutter/dispose_controllers/fix/dispose_controllers_test.dart
@@ -23,7 +23,7 @@ void main() {
       );
 
       final errors = await lint.testRun(result, pubspec: pubspec);
-      expect(errors, hasLength(9));
+      expect(errors, hasLength(10));
 
       final changes = await Future.wait([
         for (final error in errors) fix.testRun(result, error, errors),


### PR DESCRIPTION
# Description

Fixes a false positive case for `dispose_controllers` when `dispose` is already called via [cascade notation](https://dart.dev/language/operators#cascade-notation)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I have read the [CONTRIBUTING.md][contributing] document.
- [x] I have performed a self-review of my code.
- [x] I have linked the issue ticket in the description (if applicable).
- [x] I have made the necessary changes to the documentation.
- [x] I have formatted my code with `dart format .` in both `packages/pyramid_lint/` and `packages/pyramid_lint_test/`.
- [x] I have analyzed my code with `dart analyze .` in both `packages/pyramid_lint/` and `packages/pyramid_lint_test/`.
- [x] I have analyzed my code with `dart run custom_lint .` or `custom_lint .`(if you have `custom_lint` installed globally) in `packages/pyramid_lint_test/`.
- [x] I have tested my code with `dart test` in `packages/pyramid_lint_test/`.

<!-- Links -->

[contributing]: https://github.com/charlescyt/pyramid_lint/blob/main/CONTRIBUTING.md
