### PR TITLE
Fix prefer_const_constructor_declarations to support constructors with super parameters

### DIFF
--- a/packages/pyramid_lint/CHANGELOG.md
+++ b/packages/pyramid_lint/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Assist: `convert_to_for_in_iterable_indexed_loop`.
 - Lint: `specify_icon_button_tooltip`.
 
+### Fixed
+
+- Fix `prefer_const_constructor_declarations` to support constructors with super parameters.
+
 ## [2.0.3] - 2024-03-15
 
 ### Changed

--- a/packages/pyramid_lint/lib/src/lints/dart/prefer_const_constructor_declarations.dart
+++ b/packages/pyramid_lint/lib/src/lints/dart/prefer_const_constructor_declarations.dart
@@ -50,10 +50,11 @@ class PreferConstConstructorDeclarations extends PyramidLintRule {
       if (!_areAllRedirectingConstructorInvocationsConst(node)) return;
       if (!_areAllSuperConstructorInvocationsConst(node)) return;
 
-      // TODO(charlescyt): need to check if the super constructor is a const constructor when using super parameters.
       final superParameters =
           node.parameters.parameters.whereType<SuperFormalParameter>();
-      if (superParameters.isNotEmpty) return;
+      if (superParameters.isNotEmpty) {
+        if (!_isSuperConstructorConst(node)) return;
+      }
 
       final fieldInitializers = node.initializers.constructorFieldInitializers;
       if (fieldInitializers.isNotEmpty) {
@@ -80,6 +81,11 @@ class PreferConstConstructorDeclarations extends PyramidLintRule {
 
   bool _areAllFieldsFinal(ClassDeclaration node) {
     return node.members.fieldDeclarations.every((e) => e.fields.isFinal);
+  }
+
+  bool _isSuperConstructorConst(ConstructorDeclaration node) {
+    final superConstructor = node.declaredElement?.superConstructor;
+    return superConstructor?.isConst == true;
   }
 
   bool _areAllRedirectingConstructorInvocationsConst(

--- a/packages/pyramid_lint_test/test/lints/dart/prefer_const_constructor_declarations/prefer_const_constructor_declarations.dart
+++ b/packages/pyramid_lint_test/test/lints/dart/prefer_const_constructor_declarations/prefer_const_constructor_declarations.dart
@@ -7,7 +7,7 @@ class Point {
   // expect_lint: prefer_const_constructor_declarations
   Point(this.x, this.y);
 
-  // The lint will not be triggered because the super constructor is not const.
+  // The lint will not be triggered because the redirecting constructor is not const.
   Point.origin() : this(0, 0);
 
   // expect_lint: prefer_const_constructor_declarations
@@ -25,10 +25,32 @@ class Point {
 class Point3D extends Point {
   final double z;
 
+  // The lint will not be triggered because the super constructor is not const.
   Point3D(super.x, super.y, this.z);
 
   // The lint will not be triggered because the super constructor is not const.
   Point3D.origin()
+      : z = 0,
+        super.origin();
+}
+
+class Coordinate {
+  final double x;
+  final double y;
+
+  const Coordinate(this.x, this.y);
+
+  const Coordinate.origin() : this(0, 0);
+}
+
+class Coordinate3D extends Coordinate {
+  final double z;
+
+  // expect_lint: prefer_const_constructor_declarations
+  Coordinate3D(super.x, super.y, this.z);
+
+  // expect_lint: prefer_const_constructor_declarations
+  Coordinate3D.origin()
       : z = 0,
         super.origin();
 }


### PR DESCRIPTION
# Description

Fixes #20

```dart
class Point {
  final double x;
  final double y;

  const Point(this.x, this.y);
}

class Point3D extends Point {
  final double z;

  Point3D(super.x, super.y, this.z); // lint
}
```

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [X] I have read the [CONTRIBUTING.md][contributing] document.
- [X] I have performed a self-review of my code.
- [X] I have linked the issue ticket in the description (if applicable).
- [X] I have made the necessary changes to the documentation.
- [X] I have formatted my code with `dart format .` in both `packages/pyramid_lint/` and `packages/pyramid_lint_test/`.
- [X] I have analyzed my code with `dart analyze .` in both `packages/pyramid_lint/` and `packages/pyramid_lint_test/`.
- [X] I have analyzed my code with `dart run custom_lint .` or `custom_lint .`(if you have `custom_lint` installed globally) in `packages/pyramid_lint_test/`.
- [x] I have tested my code with `dart test` in `packages/pyramid_lint_test/`.

<!-- Links -->

[contributing]: https://github.com/charlescyt/pyramid_lint/blob/main/CONTRIBUTING.md
