### PR TITLE
Fix convert_to_for_in_iterable_indexed_loop docs

### DIFF
--- a/docs/dart-assists/convert_to_for_in_iterable_indexed_loop.mdx
+++ b/docs/dart-assists/convert_to_for_in_iterable_indexed_loop.mdx
@@ -6,6 +6,7 @@ Convert a `for-in` loop to a `for-in` loop that uses `iterable.indexed` instead 
 void fn(Iterable<int> numbers) {
     for (final int number in numbers) {}
 }
+```
 
 ```dart title="After"
 void fn(Iterable<int> numbers) {


### PR DESCRIPTION
# Description

Please provide a summary of the changes made in this pull request and mention the related issue.

Close the first sample code block in documentation page of `convert_to_for_in_iterable_indexed_loop`.

Fixes #65

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor
- [x] Documentation
- [ ] Other

## Checklist

- [x] I have read the [CONTRIBUTING.md][contributing] document.
- [x] I have performed a self-review of my code.
- [x] I have linked the issue ticket in the description (if applicable).
- [x] I have made the necessary changes to the documentation.
- [x] I have formatted my code with `dart format .` in both `packages/pyramid_lint/` and `packages/pyramid_lint_test/`.
- [x] I have analyzed my code with `dart analyze .` in both `packages/pyramid_lint/` and `packages/pyramid_lint_test/`.
- [x] I have analyzed my code with `dart run custom_lint .` or `custom_lint .`(if you have `custom_lint` installed globally) in `packages/pyramid_lint_test/`.
- [x] I have tested my code with `dart test` in `packages/pyramid_lint_test/`.

<!-- Links -->

[contributing]: https://github.com/charlescyt/pyramid_lint/blob/main/CONTRIBUTING.md
